### PR TITLE
Fix Broken Link in "Linux Users & Groups" Section (Closes #362)

### DIFF
--- a/2025/linux/README.md
+++ b/2025/linux/README.md
@@ -82,7 +82,7 @@ Logs are crucial in DevOps! You’ll analyze logs using the **Linux_2k.log** fil
 ---
 
 ## 📚 Resources to Get Started
-- [Linux Users & Groups](https://linuxize.com/post/how-to-create-users-and-groups-in-linux/)
+- [Linux Users & Groups](https://www.linode.com/docs/guides/linux-users-and-groups/)
 - [Linux File Permissions](https://www.redhat.com/sysadmin/linux-permissions-guide)
 - [AWK for Log Analysis](https://www.baeldung.com/linux/awk-command)
 - [Linux Volume Management](https://www.tecmint.com/create-lvm-storage-in-linux/)


### PR DESCRIPTION
This PR fixes the broken link in **Resources to Get Started** section in 2025/linux by updating it to the correct URL.

* Updated the link to ensure it works as expected.
* Verified that the new link is accessible and relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Linux user and group resource link in the training material for Week 2, ensuring access to the most current reference information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->