### PR TITLE
Change MySQL package name to mysql-client

### DIFF
--- a/2026/day-69/README.md
+++ b/2026/day-69/README.md
@@ -291,7 +291,7 @@ Write `multi-play.yml` with separate plays for each server group:
   tasks:
     - name: Install MySQL client
       yum:
-        name: mysql
+        name: mysql-client
         state: present
     - name: Create data directory
       file:


### PR DESCRIPTION
mysql package is not available in ubuntu, mysql-client is.

ubuntu@ip-172-31-33-176:~/ansible-practice$ sudo apt install mysql Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package mysql