### PR TITLE
fix: resolve ErrImagePull for MySQL helm deployment

### DIFF
--- a/2026/day-78/README.md
+++ b/2026/day-78/README.md
@@ -107,6 +107,8 @@ helm search repo bitnami/mysql
 **Deploy MySQL with the same config the AI-BankApp expects:**
 ```bash
 helm install bankapp-mysql bitnami/mysql \
+  --set image.repository=bitnamilegacy/mysql \
+  --set image.tag=9.4.0-debian-12-r1 \
   --set auth.rootPassword=Test@123 \
   --set auth.database=bankappdb \
   --set primary.resources.requests.memory=256Mi \


### PR DESCRIPTION
## Summary

Updated the Helm installation command to override the default MySQL image repository.

## Changes

- Added image.repository=bitnamilegacy/mysql
- Added image.tag=9.4.0-debian-12-r1

## Reason

The default image (bitnami/mysql:9.4.0-debian-12-r1) returned `ImagePullBackOff` because the image was no longer available in the default Bitnami repository. Switching to the legacy Bitnami repository resolved the issue and allowed the MySQL Pod to start successfully.

## Result

- MySQL Pod is running successfully.
- Helm deployment completed without image pull errors.